### PR TITLE
Allow http call configuration

### DIFF
--- a/src/WebApiTestApplication/Scripts/Endpoints/Endpoints.ts
+++ b/src/WebApiTestApplication/Scripts/Endpoints/Endpoints.ts
@@ -56,8 +56,8 @@ namespace Endpoints {
         }
     
         export interface IGetWithCall extends IGet, IEndpoint {
-            call(): ng.IPromise<string[]>;
-            callCached(): ng.IPromise<string[]>;
+            call(httpConfig?): ng.IPromise<string[]>;
+            callCached(httpConfig?): ng.IPromise<string[]>;
         }
     
         export class Get implements IGet, IEndpoint {
@@ -79,8 +79,8 @@ namespace Endpoints {
         }
     
         export interface IGet1WithCall extends IGet1, IEndpoint {
-            call(): ng.IPromise<string>;
-            callCached(): ng.IPromise<string>;
+            call(httpConfig?): ng.IPromise<string>;
+            callCached(httpConfig?): ng.IPromise<string>;
         }
     
         export class Get1 implements IGet1, IEndpoint {
@@ -116,8 +116,8 @@ namespace Endpoints {
         }
     
         export interface IGetSomethingWithCall extends IGetSomething, IEndpoint {
-            call(): ng.IPromise<string>;
-            callCached(): ng.IPromise<string>;
+            call(httpConfig?): ng.IPromise<string>;
+            callCached(httpConfig?): ng.IPromise<string>;
         }
     
         export class GetSomething implements IGetSomething, IEndpoint {
@@ -155,8 +155,8 @@ namespace Endpoints {
         }
     
         export interface IGetSomethingElseWithCall extends IGetSomethingElse, IEndpoint {
-            call(): ng.IPromise<string>;
-            callCached(): ng.IPromise<string>;
+            call(httpConfig?): ng.IPromise<string>;
+            callCached(httpConfig?): ng.IPromise<string>;
         }
     
         export class GetSomethingElse implements IGetSomethingElse, IEndpoint {
@@ -193,8 +193,8 @@ namespace Endpoints {
         }
     
         export interface IGetEnumerableStringWithCall extends IGetEnumerableString, IEndpoint {
-            call(): ng.IPromise<string[]>;
-            callCached(): ng.IPromise<string[]>;
+            call(httpConfig?): ng.IPromise<string[]>;
+            callCached(httpConfig?): ng.IPromise<string[]>;
         }
     
         export class GetEnumerableString implements IGetEnumerableString, IEndpoint {
@@ -215,8 +215,8 @@ namespace Endpoints {
         }
     
         export interface IGetIHttpActionResultWithCall extends IGetIHttpActionResult, IEndpoint {
-            call<TView>(): ng.IPromise<TView>;
-            callCached<TView>(): ng.IPromise<TView>;
+            call<TView>(httpConfig?): ng.IPromise<TView>;
+            callCached<TView>(httpConfig?): ng.IPromise<TView>;
         }
     
         export class GetIHttpActionResult implements IGetIHttpActionResult, IEndpoint {
@@ -237,8 +237,8 @@ namespace Endpoints {
         }
     
         export interface IGetVoidTaskWithCall extends IGetVoidTask, IEndpoint {
-            call(): ng.IPromise<void>;
-            callCached(): ng.IPromise<void>;
+            call(httpConfig?): ng.IPromise<void>;
+            callCached(httpConfig?): ng.IPromise<void>;
         }
     
         export class GetVoidTask implements IGetVoidTask, IEndpoint {
@@ -259,8 +259,8 @@ namespace Endpoints {
         }
     
         export interface IGetStringTaskWithCall extends IGetStringTask, IEndpoint {
-            call(): ng.IPromise<string>;
-            callCached(): ng.IPromise<string>;
+            call(httpConfig?): ng.IPromise<string>;
+            callCached(httpConfig?): ng.IPromise<string>;
         }
     
         export class GetStringTask implements IGetStringTask, IEndpoint {
@@ -281,8 +281,8 @@ namespace Endpoints {
         }
     
         export interface IGetEnumerableStringTaskWithCall extends IGetEnumerableStringTask, IEndpoint {
-            call(): ng.IPromise<string[]>;
-            callCached(): ng.IPromise<string[]>;
+            call(httpConfig?): ng.IPromise<string[]>;
+            callCached(httpConfig?): ng.IPromise<string[]>;
         }
     
         export class GetEnumerableStringTask implements IGetEnumerableStringTask, IEndpoint {
@@ -303,7 +303,7 @@ namespace Endpoints {
         }
     
         export interface IPostWithCall extends IPost, IEndpoint {
-            call(value: Interfaces.IDummyClass): ng.IPromise<string>;
+            call(value: Interfaces.IDummyClass, httpConfig?): ng.IPromise<string>;
         }
     
         export class Post implements IPost, IEndpoint {
@@ -324,7 +324,7 @@ namespace Endpoints {
         }
     
         export interface IPost1WithCall extends IPost1, IEndpoint {
-            call(value: Interfaces.IDerivedClassWithShadowedProperty): ng.IPromise<string>;
+            call(value: Interfaces.IDerivedClassWithShadowedProperty, httpConfig?): ng.IPromise<string>;
         }
     
         export class Post1 implements IPost1, IEndpoint {
@@ -345,7 +345,7 @@ namespace Endpoints {
         }
     
         export interface IPost2WithCall extends IPost2, IEndpoint {
-            call(value: Interfaces.IDerivedClassWithAnotherShadowedProperty): ng.IPromise<string>;
+            call(value: Interfaces.IDerivedClassWithAnotherShadowedProperty, httpConfig?): ng.IPromise<string>;
         }
     
         export class Post2 implements IPost2, IEndpoint {
@@ -367,7 +367,7 @@ namespace Endpoints {
         }
     
         export interface IPutWithCall extends IPut, IEndpoint {
-            call(value: string): ng.IPromise<string>;
+            call(value: string, httpConfig?): ng.IPromise<string>;
         }
     
         export class Put implements IPut, IEndpoint {
@@ -391,7 +391,7 @@ namespace Endpoints {
         }
     
         export interface IDeleteWithCall extends IDelete, IEndpoint {
-            call(): ng.IPromise<string>;
+            call(httpConfig?): ng.IPromise<string>;
         }
     
         export class Delete implements IDelete, IEndpoint {
@@ -433,8 +433,8 @@ namespace Endpoints {
         }
     
         export interface IGetAllWithCall extends IGetAll, IEndpoint {
-            call(): ng.IPromise<string>;
-            callCached(): ng.IPromise<string>;
+            call(httpConfig?): ng.IPromise<string>;
+            callCached(httpConfig?): ng.IPromise<string>;
         }
     
         export class GetAll implements IGetAll, IEndpoint {
@@ -455,8 +455,8 @@ namespace Endpoints {
         }
     
         export interface IGetWithCall extends IGet, IEndpoint {
-            call(): ng.IPromise<string>;
-            callCached(): ng.IPromise<string>;
+            call(httpConfig?): ng.IPromise<string>;
+            callCached(httpConfig?): ng.IPromise<string>;
         }
     
         export class Get implements IGet, IEndpoint {
@@ -494,8 +494,8 @@ namespace Endpoints {
         }
     
         export interface IGettyWithCall extends IGetty, IEndpoint {
-            call(): ng.IPromise<string>;
-            callCached(): ng.IPromise<string>;
+            call(httpConfig?): ng.IPromise<string>;
+            callCached(httpConfig?): ng.IPromise<string>;
         }
     
         export class Getty implements IGetty, IEndpoint {
@@ -529,7 +529,7 @@ namespace Endpoints {
         }
     
         export interface IPostWithCall extends IPost, IEndpoint {
-            call(value: Interfaces.IMegaClass): ng.IPromise<string>;
+            call(value: Interfaces.IMegaClass, httpConfig?): ng.IPromise<string>;
         }
     
         export class Post implements IPost, IEndpoint {

--- a/src/WebApiTestApplication/Scripts/Endpoints/Endpoints.ts
+++ b/src/WebApiTestApplication/Scripts/Endpoints/Endpoints.ts
@@ -56,8 +56,8 @@ namespace Endpoints {
         }
     
         export interface IGetWithCall extends IGet, IEndpoint {
-            call(httpConfig?): ng.IPromise<string[]>;
-            callCached(httpConfig?): ng.IPromise<string[]>;
+            call(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string[]>;
+            callCached(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string[]>;
         }
     
         export class Get implements IGet, IEndpoint {
@@ -79,8 +79,8 @@ namespace Endpoints {
         }
     
         export interface IGet1WithCall extends IGet1, IEndpoint {
-            call(httpConfig?): ng.IPromise<string>;
-            callCached(httpConfig?): ng.IPromise<string>;
+            call(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string>;
+            callCached(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string>;
         }
     
         export class Get1 implements IGet1, IEndpoint {
@@ -116,8 +116,8 @@ namespace Endpoints {
         }
     
         export interface IGetSomethingWithCall extends IGetSomething, IEndpoint {
-            call(httpConfig?): ng.IPromise<string>;
-            callCached(httpConfig?): ng.IPromise<string>;
+            call(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string>;
+            callCached(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string>;
         }
     
         export class GetSomething implements IGetSomething, IEndpoint {
@@ -155,8 +155,8 @@ namespace Endpoints {
         }
     
         export interface IGetSomethingElseWithCall extends IGetSomethingElse, IEndpoint {
-            call(httpConfig?): ng.IPromise<string>;
-            callCached(httpConfig?): ng.IPromise<string>;
+            call(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string>;
+            callCached(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string>;
         }
     
         export class GetSomethingElse implements IGetSomethingElse, IEndpoint {
@@ -193,8 +193,8 @@ namespace Endpoints {
         }
     
         export interface IGetEnumerableStringWithCall extends IGetEnumerableString, IEndpoint {
-            call(httpConfig?): ng.IPromise<string[]>;
-            callCached(httpConfig?): ng.IPromise<string[]>;
+            call(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string[]>;
+            callCached(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string[]>;
         }
     
         export class GetEnumerableString implements IGetEnumerableString, IEndpoint {
@@ -215,8 +215,8 @@ namespace Endpoints {
         }
     
         export interface IGetIHttpActionResultWithCall extends IGetIHttpActionResult, IEndpoint {
-            call<TView>(httpConfig?): ng.IPromise<TView>;
-            callCached<TView>(httpConfig?): ng.IPromise<TView>;
+            call<TView>(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<TView>;
+            callCached<TView>(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<TView>;
         }
     
         export class GetIHttpActionResult implements IGetIHttpActionResult, IEndpoint {
@@ -237,8 +237,8 @@ namespace Endpoints {
         }
     
         export interface IGetVoidTaskWithCall extends IGetVoidTask, IEndpoint {
-            call(httpConfig?): ng.IPromise<void>;
-            callCached(httpConfig?): ng.IPromise<void>;
+            call(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<void>;
+            callCached(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<void>;
         }
     
         export class GetVoidTask implements IGetVoidTask, IEndpoint {
@@ -259,8 +259,8 @@ namespace Endpoints {
         }
     
         export interface IGetStringTaskWithCall extends IGetStringTask, IEndpoint {
-            call(httpConfig?): ng.IPromise<string>;
-            callCached(httpConfig?): ng.IPromise<string>;
+            call(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string>;
+            callCached(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string>;
         }
     
         export class GetStringTask implements IGetStringTask, IEndpoint {
@@ -281,8 +281,8 @@ namespace Endpoints {
         }
     
         export interface IGetEnumerableStringTaskWithCall extends IGetEnumerableStringTask, IEndpoint {
-            call(httpConfig?): ng.IPromise<string[]>;
-            callCached(httpConfig?): ng.IPromise<string[]>;
+            call(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string[]>;
+            callCached(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string[]>;
         }
     
         export class GetEnumerableStringTask implements IGetEnumerableStringTask, IEndpoint {
@@ -303,7 +303,7 @@ namespace Endpoints {
         }
     
         export interface IPostWithCall extends IPost, IEndpoint {
-            call(value: Interfaces.IDummyClass, httpConfig?): ng.IPromise<string>;
+            call(value: Interfaces.IDummyClass, httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string>;
         }
     
         export class Post implements IPost, IEndpoint {
@@ -324,7 +324,7 @@ namespace Endpoints {
         }
     
         export interface IPost1WithCall extends IPost1, IEndpoint {
-            call(value: Interfaces.IDerivedClassWithShadowedProperty, httpConfig?): ng.IPromise<string>;
+            call(value: Interfaces.IDerivedClassWithShadowedProperty, httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string>;
         }
     
         export class Post1 implements IPost1, IEndpoint {
@@ -345,7 +345,7 @@ namespace Endpoints {
         }
     
         export interface IPost2WithCall extends IPost2, IEndpoint {
-            call(value: Interfaces.IDerivedClassWithAnotherShadowedProperty, httpConfig?): ng.IPromise<string>;
+            call(value: Interfaces.IDerivedClassWithAnotherShadowedProperty, httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string>;
         }
     
         export class Post2 implements IPost2, IEndpoint {
@@ -367,7 +367,7 @@ namespace Endpoints {
         }
     
         export interface IPutWithCall extends IPut, IEndpoint {
-            call(value: string, httpConfig?): ng.IPromise<string>;
+            call(value: string, httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string>;
         }
     
         export class Put implements IPut, IEndpoint {
@@ -391,7 +391,7 @@ namespace Endpoints {
         }
     
         export interface IDeleteWithCall extends IDelete, IEndpoint {
-            call(httpConfig?): ng.IPromise<string>;
+            call(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string>;
         }
     
         export class Delete implements IDelete, IEndpoint {
@@ -433,8 +433,8 @@ namespace Endpoints {
         }
     
         export interface IGetAllWithCall extends IGetAll, IEndpoint {
-            call(httpConfig?): ng.IPromise<string>;
-            callCached(httpConfig?): ng.IPromise<string>;
+            call(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string>;
+            callCached(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string>;
         }
     
         export class GetAll implements IGetAll, IEndpoint {
@@ -455,8 +455,8 @@ namespace Endpoints {
         }
     
         export interface IGetWithCall extends IGet, IEndpoint {
-            call(httpConfig?): ng.IPromise<string>;
-            callCached(httpConfig?): ng.IPromise<string>;
+            call(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string>;
+            callCached(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string>;
         }
     
         export class Get implements IGet, IEndpoint {
@@ -494,8 +494,8 @@ namespace Endpoints {
         }
     
         export interface IGettyWithCall extends IGetty, IEndpoint {
-            call(httpConfig?): ng.IPromise<string>;
-            callCached(httpConfig?): ng.IPromise<string>;
+            call(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string>;
+            callCached(httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string>;
         }
     
         export class Getty implements IGetty, IEndpoint {
@@ -529,7 +529,7 @@ namespace Endpoints {
         }
     
         export interface IPostWithCall extends IPost, IEndpoint {
-            call(value: Interfaces.IMegaClass, httpConfig?): ng.IPromise<string>;
+            call(value: Interfaces.IMegaClass, httpConfig?: angular.IRequestShortcutConfig): ng.IPromise<string>;
         }
     
         export class Post implements IPost, IEndpoint {

--- a/src/WebApiTestApplication/Scripts/Endpoints/Service.ts
+++ b/src/WebApiTestApplication/Scripts/Endpoints/Service.ts
@@ -10,7 +10,7 @@ namespace Endpoints {
             AngularEndpointsService.$q = $q;
         }
     
-        static call<TView>(endpoint: IEndpoint, data, httpConfig?) {
+        static call<TView>(endpoint: IEndpoint, data, httpConfig?: angular.IRequestShortcutConfig) {
             const config =  {
                 method: endpoint._verb,
                 url: endpoint.toString(),
@@ -19,11 +19,11 @@ namespace Endpoints {
         
             httpConfig && _.extend(config, httpConfig);
             
-            var call = AngularEndpointsService.$http<TView>(config);
+            const call = AngularEndpointsService.$http<TView>(config);
             return call.then(response => response.data);
         }
     
-        static callCached<TView>(endpoint: IEndpoint, data, httpConfig?) {
+        static callCached<TView>(endpoint: IEndpoint, data, httpConfig?: angular.IRequestShortcutConfig) {
             var cacheKey = endpoint.toString();
         
             if (this.endpointCache[cacheKey] == null) {
@@ -42,11 +42,11 @@ namespace Endpoints {
             Get: (args: Endpoints.Test.IGet): Endpoints.Test.IGetWithCall => {
                 var endpoint = new Endpoints.Test.Get(args);
                 return _.extendOwn(endpoint, {
-                    call(httpConfig?) {
+                    call(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.call<string[]>(this, null, httpConfig);
                     },
                 
-                    callCached(httpConfig?) {
+                    callCached(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.callCached<string[]>(this, null, httpConfig);
                     }
                 });
@@ -55,11 +55,11 @@ namespace Endpoints {
             Get1: (args: Endpoints.Test.IGet1): Endpoints.Test.IGet1WithCall => {
                 var endpoint = new Endpoints.Test.Get1(args);
                 return _.extendOwn(endpoint, {
-                    call(httpConfig?) {
+                    call(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.call<string>(this, null, httpConfig);
                     },
                 
-                    callCached(httpConfig?) {
+                    callCached(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.callCached<string>(this, null, httpConfig);
                     }
                 });
@@ -68,11 +68,11 @@ namespace Endpoints {
             GetSomething: (args: Endpoints.Test.IGetSomething): Endpoints.Test.IGetSomethingWithCall => {
                 var endpoint = new Endpoints.Test.GetSomething(args);
                 return _.extendOwn(endpoint, {
-                    call(httpConfig?) {
+                    call(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.call<string>(this, null, httpConfig);
                     },
                 
-                    callCached(httpConfig?) {
+                    callCached(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.callCached<string>(this, null, httpConfig);
                     }
                 });
@@ -81,11 +81,11 @@ namespace Endpoints {
             GetSomethingElse: (args: Endpoints.Test.IGetSomethingElse): Endpoints.Test.IGetSomethingElseWithCall => {
                 var endpoint = new Endpoints.Test.GetSomethingElse(args);
                 return _.extendOwn(endpoint, {
-                    call(httpConfig?) {
+                    call(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.call<string>(this, null, httpConfig);
                     },
                 
-                    callCached(httpConfig?) {
+                    callCached(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.callCached<string>(this, null, httpConfig);
                     }
                 });
@@ -94,11 +94,11 @@ namespace Endpoints {
             GetEnumerableString: (args: Endpoints.Test.IGetEnumerableString): Endpoints.Test.IGetEnumerableStringWithCall => {
                 var endpoint = new Endpoints.Test.GetEnumerableString(args);
                 return _.extendOwn(endpoint, {
-                    call(httpConfig?) {
+                    call(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.call<string[]>(this, null, httpConfig);
                     },
                 
-                    callCached(httpConfig?) {
+                    callCached(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.callCached<string[]>(this, null, httpConfig);
                     }
                 });
@@ -107,11 +107,11 @@ namespace Endpoints {
             GetIHttpActionResult: (args: Endpoints.Test.IGetIHttpActionResult): Endpoints.Test.IGetIHttpActionResultWithCall => {
                 var endpoint = new Endpoints.Test.GetIHttpActionResult(args);
                 return _.extendOwn(endpoint, {
-                    call<TView>(httpConfig?) {
+                    call<TView>(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.call<TView>(this, null, httpConfig);
                     },
                 
-                    callCached<TView>(httpConfig?) {
+                    callCached<TView>(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.callCached<TView>(this, null, httpConfig);
                     }
                 });
@@ -120,11 +120,11 @@ namespace Endpoints {
             GetVoidTask: (args: Endpoints.Test.IGetVoidTask): Endpoints.Test.IGetVoidTaskWithCall => {
                 var endpoint = new Endpoints.Test.GetVoidTask(args);
                 return _.extendOwn(endpoint, {
-                    call(httpConfig?) {
+                    call(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.call<void>(this, null, httpConfig);
                     },
                 
-                    callCached(httpConfig?) {
+                    callCached(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.callCached<void>(this, null, httpConfig);
                     }
                 });
@@ -133,11 +133,11 @@ namespace Endpoints {
             GetStringTask: (args: Endpoints.Test.IGetStringTask): Endpoints.Test.IGetStringTaskWithCall => {
                 var endpoint = new Endpoints.Test.GetStringTask(args);
                 return _.extendOwn(endpoint, {
-                    call(httpConfig?) {
+                    call(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.call<string>(this, null, httpConfig);
                     },
                 
-                    callCached(httpConfig?) {
+                    callCached(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.callCached<string>(this, null, httpConfig);
                     }
                 });
@@ -146,11 +146,11 @@ namespace Endpoints {
             GetEnumerableStringTask: (args: Endpoints.Test.IGetEnumerableStringTask): Endpoints.Test.IGetEnumerableStringTaskWithCall => {
                 var endpoint = new Endpoints.Test.GetEnumerableStringTask(args);
                 return _.extendOwn(endpoint, {
-                    call(httpConfig?) {
+                    call(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.call<string[]>(this, null, httpConfig);
                     },
                 
-                    callCached(httpConfig?) {
+                    callCached(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.callCached<string[]>(this, null, httpConfig);
                     }
                 });
@@ -159,7 +159,7 @@ namespace Endpoints {
             Post: (args: Endpoints.Test.IPost): Endpoints.Test.IPostWithCall => {
                 var endpoint = new Endpoints.Test.Post(args);
                 return _.extendOwn(endpoint, {
-                    call(value: Interfaces.IDummyClass, httpConfig?) {
+                    call(value: Interfaces.IDummyClass, httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.call<string>(this, value != null ? value : null, httpConfig);
                     },
                 });
@@ -168,7 +168,7 @@ namespace Endpoints {
             Post1: (args: Endpoints.Test.IPost1): Endpoints.Test.IPost1WithCall => {
                 var endpoint = new Endpoints.Test.Post1(args);
                 return _.extendOwn(endpoint, {
-                    call(value: Interfaces.IDerivedClassWithShadowedProperty, httpConfig?) {
+                    call(value: Interfaces.IDerivedClassWithShadowedProperty, httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.call<string>(this, value != null ? value : null, httpConfig);
                     },
                 });
@@ -177,7 +177,7 @@ namespace Endpoints {
             Post2: (args: Endpoints.Test.IPost2): Endpoints.Test.IPost2WithCall => {
                 var endpoint = new Endpoints.Test.Post2(args);
                 return _.extendOwn(endpoint, {
-                    call(value: Interfaces.IDerivedClassWithAnotherShadowedProperty, httpConfig?) {
+                    call(value: Interfaces.IDerivedClassWithAnotherShadowedProperty, httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.call<string>(this, value != null ? value : null, httpConfig);
                     },
                 });
@@ -186,7 +186,7 @@ namespace Endpoints {
             Put: (args: Endpoints.Test.IPut): Endpoints.Test.IPutWithCall => {
                 var endpoint = new Endpoints.Test.Put(args);
                 return _.extendOwn(endpoint, {
-                    call(value: string, httpConfig?) {
+                    call(value: string, httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.call<string>(this, value != null ? `"${value}"` : null, httpConfig);
                     },
                 });
@@ -195,7 +195,7 @@ namespace Endpoints {
             Delete: (args: Endpoints.Test.IDelete): Endpoints.Test.IDeleteWithCall => {
                 var endpoint = new Endpoints.Test.Delete(args);
                 return _.extendOwn(endpoint, {
-                    call(httpConfig?) {
+                    call(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.call<string>(this, null, httpConfig);
                     },
                 });
@@ -206,11 +206,11 @@ namespace Endpoints {
             GetAll: (args?: Endpoints.Thingy.IGetAll): Endpoints.Thingy.IGetAllWithCall => {
                 var endpoint = new Endpoints.Thingy.GetAll(args);
                 return _.extendOwn(endpoint, {
-                    call(httpConfig?) {
+                    call(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.call<string>(this, null, httpConfig);
                     },
                 
-                    callCached(httpConfig?) {
+                    callCached(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.callCached<string>(this, null, httpConfig);
                     }
                 });
@@ -219,11 +219,11 @@ namespace Endpoints {
             Get: (args: Endpoints.Thingy.IGet): Endpoints.Thingy.IGetWithCall => {
                 var endpoint = new Endpoints.Thingy.Get(args);
                 return _.extendOwn(endpoint, {
-                    call(httpConfig?) {
+                    call(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.call<string>(this, null, httpConfig);
                     },
                 
-                    callCached(httpConfig?) {
+                    callCached(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.callCached<string>(this, null, httpConfig);
                     }
                 });
@@ -232,11 +232,11 @@ namespace Endpoints {
             Getty: (args: Endpoints.Thingy.IGetty): Endpoints.Thingy.IGettyWithCall => {
                 var endpoint = new Endpoints.Thingy.Getty(args);
                 return _.extendOwn(endpoint, {
-                    call(httpConfig?) {
+                    call(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.call<string>(this, null, httpConfig);
                     },
                 
-                    callCached(httpConfig?) {
+                    callCached(httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.callCached<string>(this, null, httpConfig);
                     }
                 });
@@ -245,7 +245,7 @@ namespace Endpoints {
             Post: (args?: Endpoints.Thingy.IPost): Endpoints.Thingy.IPostWithCall => {
                 var endpoint = new Endpoints.Thingy.Post(args);
                 return _.extendOwn(endpoint, {
-                    call(value: Interfaces.IMegaClass, httpConfig?) {
+                    call(value: Interfaces.IMegaClass, httpConfig?: angular.IRequestShortcutConfig) {
                         return AngularEndpointsService.call<string>(this, value != null ? value : null, httpConfig);
                     },
                 });

--- a/src/WebApiTestApplication/Scripts/Endpoints/Service.ts
+++ b/src/WebApiTestApplication/Scripts/Endpoints/Service.ts
@@ -10,21 +10,24 @@ namespace Endpoints {
             AngularEndpointsService.$q = $q;
         }
     
-        static call<TView>(endpoint: IEndpoint, data) {
-            var call = AngularEndpointsService.$http<TView>({
+        static call<TView>(endpoint: IEndpoint, data, httpConfig?) {
+            const config =  {
                 method: endpoint._verb,
                 url: endpoint.toString(),
                 data: data
-            });
+            }
         
+            httpConfig && _.extend(config, httpConfig);
+            
+            var call = AngularEndpointsService.$http<TView>(config);
             return call.then(response => response.data);
         }
     
-        static callCached<TView>(endpoint: IEndpoint, data) {
+        static callCached<TView>(endpoint: IEndpoint, data, httpConfig?) {
             var cacheKey = endpoint.toString();
         
             if (this.endpointCache[cacheKey] == null) {
-                return this.call<TView>(endpoint, data).then(result => {
+                return this.call<TView>(endpoint, data, httpConfig).then(result => {
                     this.endpointCache[cacheKey] = result;
                     return this.endpointCache[cacheKey];
                 });
@@ -39,12 +42,12 @@ namespace Endpoints {
             Get: (args: Endpoints.Test.IGet): Endpoints.Test.IGetWithCall => {
                 var endpoint = new Endpoints.Test.Get(args);
                 return _.extendOwn(endpoint, {
-                    call() {
-                        return AngularEndpointsService.call<string[]>(this, null);
+                    call(httpConfig?) {
+                        return AngularEndpointsService.call<string[]>(this, null, httpConfig);
                     },
                 
-                    callCached() {
-                        return AngularEndpointsService.callCached<string[]>(this, null);
+                    callCached(httpConfig?) {
+                        return AngularEndpointsService.callCached<string[]>(this, null, httpConfig);
                     }
                 });
             },
@@ -52,12 +55,12 @@ namespace Endpoints {
             Get1: (args: Endpoints.Test.IGet1): Endpoints.Test.IGet1WithCall => {
                 var endpoint = new Endpoints.Test.Get1(args);
                 return _.extendOwn(endpoint, {
-                    call() {
-                        return AngularEndpointsService.call<string>(this, null);
+                    call(httpConfig?) {
+                        return AngularEndpointsService.call<string>(this, null, httpConfig);
                     },
                 
-                    callCached() {
-                        return AngularEndpointsService.callCached<string>(this, null);
+                    callCached(httpConfig?) {
+                        return AngularEndpointsService.callCached<string>(this, null, httpConfig);
                     }
                 });
             },
@@ -65,12 +68,12 @@ namespace Endpoints {
             GetSomething: (args: Endpoints.Test.IGetSomething): Endpoints.Test.IGetSomethingWithCall => {
                 var endpoint = new Endpoints.Test.GetSomething(args);
                 return _.extendOwn(endpoint, {
-                    call() {
-                        return AngularEndpointsService.call<string>(this, null);
+                    call(httpConfig?) {
+                        return AngularEndpointsService.call<string>(this, null, httpConfig);
                     },
                 
-                    callCached() {
-                        return AngularEndpointsService.callCached<string>(this, null);
+                    callCached(httpConfig?) {
+                        return AngularEndpointsService.callCached<string>(this, null, httpConfig);
                     }
                 });
             },
@@ -78,12 +81,12 @@ namespace Endpoints {
             GetSomethingElse: (args: Endpoints.Test.IGetSomethingElse): Endpoints.Test.IGetSomethingElseWithCall => {
                 var endpoint = new Endpoints.Test.GetSomethingElse(args);
                 return _.extendOwn(endpoint, {
-                    call() {
-                        return AngularEndpointsService.call<string>(this, null);
+                    call(httpConfig?) {
+                        return AngularEndpointsService.call<string>(this, null, httpConfig);
                     },
                 
-                    callCached() {
-                        return AngularEndpointsService.callCached<string>(this, null);
+                    callCached(httpConfig?) {
+                        return AngularEndpointsService.callCached<string>(this, null, httpConfig);
                     }
                 });
             },
@@ -91,12 +94,12 @@ namespace Endpoints {
             GetEnumerableString: (args: Endpoints.Test.IGetEnumerableString): Endpoints.Test.IGetEnumerableStringWithCall => {
                 var endpoint = new Endpoints.Test.GetEnumerableString(args);
                 return _.extendOwn(endpoint, {
-                    call() {
-                        return AngularEndpointsService.call<string[]>(this, null);
+                    call(httpConfig?) {
+                        return AngularEndpointsService.call<string[]>(this, null, httpConfig);
                     },
                 
-                    callCached() {
-                        return AngularEndpointsService.callCached<string[]>(this, null);
+                    callCached(httpConfig?) {
+                        return AngularEndpointsService.callCached<string[]>(this, null, httpConfig);
                     }
                 });
             },
@@ -104,12 +107,12 @@ namespace Endpoints {
             GetIHttpActionResult: (args: Endpoints.Test.IGetIHttpActionResult): Endpoints.Test.IGetIHttpActionResultWithCall => {
                 var endpoint = new Endpoints.Test.GetIHttpActionResult(args);
                 return _.extendOwn(endpoint, {
-                    call<TView>() {
-                        return AngularEndpointsService.call<TView>(this, null);
+                    call<TView>(httpConfig?) {
+                        return AngularEndpointsService.call<TView>(this, null, httpConfig);
                     },
                 
-                    callCached<TView>() {
-                        return AngularEndpointsService.callCached<TView>(this, null);
+                    callCached<TView>(httpConfig?) {
+                        return AngularEndpointsService.callCached<TView>(this, null, httpConfig);
                     }
                 });
             },
@@ -117,12 +120,12 @@ namespace Endpoints {
             GetVoidTask: (args: Endpoints.Test.IGetVoidTask): Endpoints.Test.IGetVoidTaskWithCall => {
                 var endpoint = new Endpoints.Test.GetVoidTask(args);
                 return _.extendOwn(endpoint, {
-                    call() {
-                        return AngularEndpointsService.call<void>(this, null);
+                    call(httpConfig?) {
+                        return AngularEndpointsService.call<void>(this, null, httpConfig);
                     },
                 
-                    callCached() {
-                        return AngularEndpointsService.callCached<void>(this, null);
+                    callCached(httpConfig?) {
+                        return AngularEndpointsService.callCached<void>(this, null, httpConfig);
                     }
                 });
             },
@@ -130,12 +133,12 @@ namespace Endpoints {
             GetStringTask: (args: Endpoints.Test.IGetStringTask): Endpoints.Test.IGetStringTaskWithCall => {
                 var endpoint = new Endpoints.Test.GetStringTask(args);
                 return _.extendOwn(endpoint, {
-                    call() {
-                        return AngularEndpointsService.call<string>(this, null);
+                    call(httpConfig?) {
+                        return AngularEndpointsService.call<string>(this, null, httpConfig);
                     },
                 
-                    callCached() {
-                        return AngularEndpointsService.callCached<string>(this, null);
+                    callCached(httpConfig?) {
+                        return AngularEndpointsService.callCached<string>(this, null, httpConfig);
                     }
                 });
             },
@@ -143,12 +146,12 @@ namespace Endpoints {
             GetEnumerableStringTask: (args: Endpoints.Test.IGetEnumerableStringTask): Endpoints.Test.IGetEnumerableStringTaskWithCall => {
                 var endpoint = new Endpoints.Test.GetEnumerableStringTask(args);
                 return _.extendOwn(endpoint, {
-                    call() {
-                        return AngularEndpointsService.call<string[]>(this, null);
+                    call(httpConfig?) {
+                        return AngularEndpointsService.call<string[]>(this, null, httpConfig);
                     },
                 
-                    callCached() {
-                        return AngularEndpointsService.callCached<string[]>(this, null);
+                    callCached(httpConfig?) {
+                        return AngularEndpointsService.callCached<string[]>(this, null, httpConfig);
                     }
                 });
             },
@@ -156,8 +159,8 @@ namespace Endpoints {
             Post: (args: Endpoints.Test.IPost): Endpoints.Test.IPostWithCall => {
                 var endpoint = new Endpoints.Test.Post(args);
                 return _.extendOwn(endpoint, {
-                    call(value: Interfaces.IDummyClass) {
-                        return AngularEndpointsService.call<string>(this, value != null ? value : null);
+                    call(value: Interfaces.IDummyClass, httpConfig?) {
+                        return AngularEndpointsService.call<string>(this, value != null ? value : null, httpConfig);
                     },
                 });
             },
@@ -165,8 +168,8 @@ namespace Endpoints {
             Post1: (args: Endpoints.Test.IPost1): Endpoints.Test.IPost1WithCall => {
                 var endpoint = new Endpoints.Test.Post1(args);
                 return _.extendOwn(endpoint, {
-                    call(value: Interfaces.IDerivedClassWithShadowedProperty) {
-                        return AngularEndpointsService.call<string>(this, value != null ? value : null);
+                    call(value: Interfaces.IDerivedClassWithShadowedProperty, httpConfig?) {
+                        return AngularEndpointsService.call<string>(this, value != null ? value : null, httpConfig);
                     },
                 });
             },
@@ -174,8 +177,8 @@ namespace Endpoints {
             Post2: (args: Endpoints.Test.IPost2): Endpoints.Test.IPost2WithCall => {
                 var endpoint = new Endpoints.Test.Post2(args);
                 return _.extendOwn(endpoint, {
-                    call(value: Interfaces.IDerivedClassWithAnotherShadowedProperty) {
-                        return AngularEndpointsService.call<string>(this, value != null ? value : null);
+                    call(value: Interfaces.IDerivedClassWithAnotherShadowedProperty, httpConfig?) {
+                        return AngularEndpointsService.call<string>(this, value != null ? value : null, httpConfig);
                     },
                 });
             },
@@ -183,8 +186,8 @@ namespace Endpoints {
             Put: (args: Endpoints.Test.IPut): Endpoints.Test.IPutWithCall => {
                 var endpoint = new Endpoints.Test.Put(args);
                 return _.extendOwn(endpoint, {
-                    call(value: string) {
-                        return AngularEndpointsService.call<string>(this, value != null ? `"${value}"` : null);
+                    call(value: string, httpConfig?) {
+                        return AngularEndpointsService.call<string>(this, value != null ? `"${value}"` : null, httpConfig);
                     },
                 });
             },
@@ -192,8 +195,8 @@ namespace Endpoints {
             Delete: (args: Endpoints.Test.IDelete): Endpoints.Test.IDeleteWithCall => {
                 var endpoint = new Endpoints.Test.Delete(args);
                 return _.extendOwn(endpoint, {
-                    call() {
-                        return AngularEndpointsService.call<string>(this, null);
+                    call(httpConfig?) {
+                        return AngularEndpointsService.call<string>(this, null, httpConfig);
                     },
                 });
             }
@@ -203,12 +206,12 @@ namespace Endpoints {
             GetAll: (args?: Endpoints.Thingy.IGetAll): Endpoints.Thingy.IGetAllWithCall => {
                 var endpoint = new Endpoints.Thingy.GetAll(args);
                 return _.extendOwn(endpoint, {
-                    call() {
-                        return AngularEndpointsService.call<string>(this, null);
+                    call(httpConfig?) {
+                        return AngularEndpointsService.call<string>(this, null, httpConfig);
                     },
                 
-                    callCached() {
-                        return AngularEndpointsService.callCached<string>(this, null);
+                    callCached(httpConfig?) {
+                        return AngularEndpointsService.callCached<string>(this, null, httpConfig);
                     }
                 });
             },
@@ -216,12 +219,12 @@ namespace Endpoints {
             Get: (args: Endpoints.Thingy.IGet): Endpoints.Thingy.IGetWithCall => {
                 var endpoint = new Endpoints.Thingy.Get(args);
                 return _.extendOwn(endpoint, {
-                    call() {
-                        return AngularEndpointsService.call<string>(this, null);
+                    call(httpConfig?) {
+                        return AngularEndpointsService.call<string>(this, null, httpConfig);
                     },
                 
-                    callCached() {
-                        return AngularEndpointsService.callCached<string>(this, null);
+                    callCached(httpConfig?) {
+                        return AngularEndpointsService.callCached<string>(this, null, httpConfig);
                     }
                 });
             },
@@ -229,12 +232,12 @@ namespace Endpoints {
             Getty: (args: Endpoints.Thingy.IGetty): Endpoints.Thingy.IGettyWithCall => {
                 var endpoint = new Endpoints.Thingy.Getty(args);
                 return _.extendOwn(endpoint, {
-                    call() {
-                        return AngularEndpointsService.call<string>(this, null);
+                    call(httpConfig?) {
+                        return AngularEndpointsService.call<string>(this, null, httpConfig);
                     },
                 
-                    callCached() {
-                        return AngularEndpointsService.callCached<string>(this, null);
+                    callCached(httpConfig?) {
+                        return AngularEndpointsService.callCached<string>(this, null, httpConfig);
                     }
                 });
             },
@@ -242,8 +245,8 @@ namespace Endpoints {
             Post: (args?: Endpoints.Thingy.IPost): Endpoints.Thingy.IPostWithCall => {
                 var endpoint = new Endpoints.Thingy.Post(args);
                 return _.extendOwn(endpoint, {
-                    call(value: Interfaces.IMegaClass) {
-                        return AngularEndpointsService.call<string>(this, value != null ? value : null);
+                    call(value: Interfaces.IMegaClass, httpConfig?) {
+                        return AngularEndpointsService.call<string>(this, value != null ? value : null, httpConfig);
                     },
                 });
             }

--- a/src/WebApiToTypeScript/Endpoints/AngularEndpointsService.cs
+++ b/src/WebApiToTypeScript/Endpoints/AngularEndpointsService.cs
@@ -28,22 +28,25 @@ namespace WebApiToTypeScript.Endpoints
                 .AddStatement($"{Config.ServiceName}.$http = $http;")
                 .AddStatement($"{Config.ServiceName}.$q = $q;", condition: Config.EndpointsSupportCaching)
                 .Parent
-                .AddAndUseBlock("static call<TView>(endpoint: IEndpoint, data)")
-                .AddAndUseBlock($"var call = {Config.ServiceName}.$http<TView>(", isFunctionBlock: true, terminationString: ";")
+                .AddAndUseBlock("static call<TView>(endpoint: IEndpoint, data, httpConfig?: angular.IRequestShortcutConfig)")
+                .AddAndUseBlock("const config = ")
                 .AddStatement("method: endpoint._verb,")
                 .AddStatement("url: endpoint.toString(),")
                 .AddStatement("data: data")
                 .Parent
+                .AddStatement("httpConfig && _.extend(config, httpConfig);")
+                .AddStatement("")
+                .AddStatement($"const call = {Config.ServiceName}.$http<TView>(config);")
                 .AddStatement("return call.then(response => response.data);");
 
             if (Config.EndpointsSupportCaching)
             {
                 serviceBlock
                     .Parent
-                    .AddAndUseBlock("static callCached<TView>(endpoint: IEndpoint, data)")
+                    .AddAndUseBlock("static callCached<TView>(endpoint: IEndpoint, data, httpConfig?: angular.IRequestShortcutConfig)")
                     .AddStatement("var cacheKey = endpoint.toString();")
                     .AddAndUseBlock("if (this.endpointCache[cacheKey] == null)")
-                    .AddAndUseBlock("return this.call<TView>(endpoint, data).then(result =>", isFunctionBlock: true,
+                    .AddAndUseBlock("return this.call<TView>(endpoint, data, httpConfig).then(result =>", isFunctionBlock: true,
                         terminationString: ";")
                     .AddStatement("this.endpointCache[cacheKey] = result;")
                     .AddStatement("return this.endpointCache[cacheKey];")

--- a/src/WebApiToTypeScript/Endpoints/EndpointsService.cs
+++ b/src/WebApiToTypeScript/Endpoints/EndpointsService.cs
@@ -111,11 +111,13 @@ namespace WebApiToTypeScript.Endpoints
         {
             var callArguments = action.BodyParameters;
 
-            var callArgumentStrings = callArguments
+            var callArgument = callArguments
                 .Select(a => a.GetParameterString(withOptionals: false, interfaceName: true))
                 .SingleOrDefault();
 
-            var callArgumentsList = string.Join(", ", callArgumentStrings);
+            var callArgumentsList = string.IsNullOrWhiteSpace(callArgument)
+                ? "httpConfig?"
+                : $"{callArgument}, httpConfig?";
 
             string typeScriptReturnType, typeScriptTypeForCall;
 

--- a/src/WebApiToTypeScript/Endpoints/EndpointsService.cs
+++ b/src/WebApiToTypeScript/Endpoints/EndpointsService.cs
@@ -116,8 +116,8 @@ namespace WebApiToTypeScript.Endpoints
                 .SingleOrDefault();
 
             var callArgumentsList = string.IsNullOrWhiteSpace(callArgument)
-                ? "httpConfig?"
-                : $"{callArgument}, httpConfig?";
+                ? "httpConfig?: angular.IRequestShortcutConfig"
+                : $"{callArgument}, httpConfig?: angular.IRequestShortcutConfig";
 
             string typeScriptReturnType, typeScriptTypeForCall;
 

--- a/src/WebApiToTypeScript/WebApi/WebApiAction.cs
+++ b/src/WebApiToTypeScript/WebApi/WebApiAction.cs
@@ -103,8 +103,8 @@ namespace WebApiToTypeScript.WebApi
                 .SingleOrDefault();
 
             return (!isFormBody || string.IsNullOrEmpty(callArgumentValueString))
-                 ? "null"
-                 : callArgumentValueString;
+                 ? "null, httpConfig"
+                 : $"{callArgumentValueString}, httpConfig";
         }
 
         public string GetCallArgumentDefinition(WebApiHttpVerb verb)
@@ -112,11 +112,15 @@ namespace WebApiToTypeScript.WebApi
             var isFormBody = verb == WebApiHttpVerb.Post || verb == WebApiHttpVerb.Put;
 
             if (!isFormBody)
-                return string.Empty;
+                return "httpConfig?: angular.IRequestShortcutConfig";
 
-            return BodyParameters
+            var bodyParam = BodyParameters
                 .Select(a => a.GetParameterString(withOptionals: false, interfaceName: true))
                 .SingleOrDefault();
+
+            return string.IsNullOrWhiteSpace(bodyParam)
+                ? "httpConfig?: angular.IRequestShortcutConfig"
+                : $"{bodyParam}, httpConfig?: angular.IRequestShortcutConfig";
         }
 
         public string GetConstructorParameterNamesList()


### PR DESCRIPTION
This effectively fixes #3 and also allows configuration of other options.
As  `httpConfig` is an optional parameter no Watts config option should be
needed to maintain compatibility.

It seemed to me that `angular.IRequestShortcutConfig` is the best candidate 
interface for `httpConfig` but that is up for debate.