### PR TITLE
Issue 27 improve es5 performance

### DIFF
--- a/Watts.nuspec
+++ b/Watts.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>WebApiToTypeScript</id>
-    <version>1.11.1</version>
+    <version>2.0.0</version>
     <authors>Balakrishnan (Balki) Ranganathan</authors>
     <owners>Balakrishnan (Balki) Ranganathan</owners>
     <licenseUrl>https://raw.githubusercontent.com/greymind/WebApiToTypeScript/master/LICENSE</licenseUrl>
@@ -10,7 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A tool for code generating TypeScript endpoints, interfaces, enums, resources and view paths for your ASP.NET Web API controllers/web apps</description>
     <summary>A tool for code generating TypeScript endpoints, interfaces, enums, resources and view paths for your ASP.NET Web API controllers/web apps</summary>
-    <releaseNotes>Fix getting base types in certain cases</releaseNotes>
+    <releaseNotes>Optimize code for execution and size when compiling TypeScript to ES5.</releaseNotes>
     <copyright>Copyright (c) 2016-2017 Balakrishnan (Balki) Ranganathan</copyright>
     <tags>WebAPI TypeScript Endpoint Enum Interface Code Generation Angular Service Balki Greymind Watts</tags>
   </metadata>

--- a/Watts.nuspec
+++ b/Watts.nuspec
@@ -10,7 +10,11 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A tool for code generating TypeScript endpoints, interfaces, enums, resources and view paths for your ASP.NET Web API controllers/web apps</description>
     <summary>A tool for code generating TypeScript endpoints, interfaces, enums, resources and view paths for your ASP.NET Web API controllers/web apps</summary>
-    <releaseNotes>Optimize code for execution and size when compiling TypeScript to ES5.</releaseNotes>
+    <releaseNotes>
+      Optimize code for execution and size when compiling TypeScript to ES5. Rendering of endpoints to query string is changed, 
+      and default getQueryParams has been removed.
+      However, endpoints can still override it's params if user explicitly implements getQueryParams method.
+    </releaseNotes>
     <copyright>Copyright (c) 2016-2017 Balakrishnan (Balki) Ranganathan</copyright>
     <tags>WebAPI TypeScript Endpoint Enum Interface Code Generation Angular Service Balki Greymind Watts</tags>
   </metadata>

--- a/src/Watts/Program.cs
+++ b/src/Watts/Program.cs
@@ -17,7 +17,7 @@ namespace Watts
             }
             else if (args.Length > 0 && File.Exists(args[0]))
             {
-                watts.ConfigFilePath = args[1];
+                watts.ConfigFilePath = args[0];
             }
 
             int status = 0;

--- a/src/Watts/Program.cs
+++ b/src/Watts/Program.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Diagnostics;
+using System.IO;
 
 namespace Watts
 {
@@ -6,22 +8,34 @@ namespace Watts
     {
         private static int Main(string[] args)
         {
-            if (args.Length != 1)
+            var watts = new WebApiToTypeScript.WebApiToTypeScript();
+            if (args.Length == 0)
             {
-                Console.WriteLine("Usage: Watts.exe <\"Path/To/Config.json\">");
-                return 1;
+                var path = Path.Combine(Environment.CurrentDirectory, "watts.config.json");
+                if (File.Exists(path))
+                    watts.ConfigFilePath = path;
+            }
+            else if (args.Length > 0 && File.Exists(args[0]))
+            {
+                watts.ConfigFilePath = args[1];
             }
 
-            var watts = new WebApiToTypeScript.WebApiToTypeScript
+            int status = 0;
+            if (watts.ConfigFilePath == null)
             {
-                ConfigFilePath = args[0]
-            };
+                Console.WriteLine("Usage: Watts.exe <\"Path/To/Config.json\">");
+                status = -1;
+            }
+            else
+            {
+                status = watts.Execute() ? 0 : -1;
+            }
 
-            watts.Execute();
-
-#if DEBUG
-            Console.ReadLine();
-#endif
+            if (Debugger.IsAttached)
+            {
+                Console.WriteLine("Press any key to continue . . .");
+                Console.ReadLine();
+            }
 
             return 0;
         }

--- a/src/WebApiToTypeScript/Config/Config.cs
+++ b/src/WebApiToTypeScript/Config/Config.cs
@@ -60,6 +60,9 @@ namespace WebApiToTypeScript.Config
         public bool GenerateInterfaces { get; set; }
             = true;
 
+        public bool GenerateInterfaceClasses { get; set; }
+            = true;
+
         public string InterfacesOutputDirectory { get; set; }
             = "Interfaces";
 

--- a/src/WebApiToTypeScript/Config/TypeMapping.cs
+++ b/src/WebApiToTypeScript/Config/TypeMapping.cs
@@ -3,6 +3,7 @@
     public class TypeMapping
     {
         public string WebApiTypeName { get; set; }
+
         public string TypeScriptTypeName { get; set; }
 
         public bool TreatAsAttribute { get; set; }
@@ -15,5 +16,10 @@
             = false;
 
         public string Match { get; set; }
+
+        public override string ToString()
+        {
+            return $"{WebApiTypeName} -> {TypeScriptTypeName}";
+        }
     }
 }

--- a/src/WebApiToTypeScript/Interfaces/InterfaceService.cs
+++ b/src/WebApiToTypeScript/Interfaces/InterfaceService.cs
@@ -227,8 +227,12 @@ namespace WebApiToTypeScript.Interfaces
             var interfaceBlock = interfacesBlock
                 .AddAndUseBlock($"export interface I{blockTypeName}{parameterOrInstanceString}{interfaceExtendsString}");
 
-            var classBlock = interfacesBlock
-                .AddAndUseBlock($"export class {blockTypeName}{parameterOrInstanceString}{classExtendsString}{classImplementsString}");
+            TypeScriptBlock classBlock = null;
+            if (Config.GenerateInterfaceClasses)
+            {
+                classBlock = interfacesBlock
+                                    .AddAndUseBlock($"export class {blockTypeName}{parameterOrInstanceString}{classExtendsString}{classImplementsString}");
+            }
 
             var things = GetMembers(typeDefinition);
 
@@ -290,22 +294,28 @@ namespace WebApiToTypeScript.Interfaces
                 interfaceBlock
                     .AddStatement($"{thingName}: {interfaceName}{collectionString};");
 
-                classBlock
-                    .AddStatement($"{thingName}: {typeName}{collectionString};");
+                if (Config.GenerateInterfaceClasses)
+                {
+                    classBlock
+                        .AddStatement($"{thingName}: {typeName}{collectionString};");
+                }
             }
 
-            if (hasBaseClass)
+            if (Config.GenerateInterfaceClasses)
             {
-                classBlock
-                   .AddAndUseBlock("constructor()")
-                   .AddStatement("super();");
-            }
+                if (hasBaseClass)
+                {
+                    classBlock
+                       .AddAndUseBlock("constructor()")
+                       .AddStatement("super();");
+                }
 
-            if (Config.GenerateEndpoints || Config.GenerateService)
-            {
-                classBlock
-                    .AddAndUseBlock("getQueryParams()")
-                    .AddStatement("return this;");
+                if (Config.GenerateEndpoints || Config.GenerateService)
+                {
+                    classBlock
+                        .AddAndUseBlock("getQueryParams()")
+                        .AddStatement("return this;");
+                }
             }
         }
 

--- a/src/WebApiToTypeScript/Interfaces/InterfaceService.cs
+++ b/src/WebApiToTypeScript/Interfaces/InterfaceService.cs
@@ -67,7 +67,7 @@ namespace WebApiToTypeScript.Interfaces
         public InterfaceNode AddInterfaceNode(TypeDefinition typeDefinition)
         {
             Debug.Assert(typeDefinition != null);
-
+            
             var interfaceNode = SearchForInterfaceNode(InterfaceNode, typeDefinition);
 
             if (interfaceNode != null)
@@ -212,13 +212,9 @@ namespace WebApiToTypeScript.Interfaces
                 LogMessage($"Interface name [{blockTypeName}] of type [{typeDefinition.FullName}] is invalid!");
                 return;
             }
-
-            var iHaveQueryParams = Config.GenerateEndpoints || Config.GenerateService
-                ? $", {Config.EndpointsNamespace}.{nameof(IHaveQueryParams)}"
-                : string.Empty;
-
+            
             var classImplementsString =
-                $" implements I{blockTypeName}{implementsString}{iHaveQueryParams}";
+                $" implements I{blockTypeName}{implementsString}";
 
             var parameterOrInstanceString = iHaveGenericParameters
                 ? implementsString

--- a/src/WebApiToTypeScript/Interfaces/InterfaceService.cs
+++ b/src/WebApiToTypeScript/Interfaces/InterfaceService.cs
@@ -304,14 +304,7 @@ namespace WebApiToTypeScript.Interfaces
                     classBlock
                        .AddAndUseBlock("constructor()")
                        .AddStatement("super();");
-                }
-
-                if (Config.GenerateEndpoints || Config.GenerateService)
-                {
-                    classBlock
-                        .AddAndUseBlock("getQueryParams()")
-                        .AddStatement("return this;");
-                }
+                }               
             }
         }
 

--- a/src/WebApiToTypeScript/Resources/ResourceService.cs
+++ b/src/WebApiToTypeScript/Resources/ResourceService.cs
@@ -17,10 +17,14 @@ namespace WebApiToTypeScript.Resources
             foreach (var resourceConfig in Config.ResourceConfigs)
             {
                 var resourceFilename = Path.GetFileNameWithoutExtension(resourceConfig.SourcePath);
+                var resourceInterface = $"I{resourceFilename}";
                 var resourceBlock = CreateResourceBlock();
 
-                var block = resourceBlock
-                    .AddAndUseBlock($"export var {resourceFilename} = ");
+                var interfaceBlock = resourceBlock
+                    .AddAndUseBlock($"export interface {resourceInterface}");
+
+                var varBlock = resourceBlock
+                    .AddAndUseBlock($"export var {resourceFilename} : {resourceInterface} = ");
 
                 var resourceReader = new ResXResourceReader(resourceConfig.SourcePath);
                 var dictionary = resourceReader.GetEnumerator();
@@ -63,13 +67,19 @@ namespace WebApiToTypeScript.Resources
                             .Aggregate(originalValue, (current, parameterTransform) => current.Replace(parameterTransform.Source, parameterTransform.Destination))
                             .Replace("{", "${");
 
-                        block
+                        interfaceBlock
+                            .AddStatement($"{dictionary.Key} : ({paramsString}) => string;");
+
+                        varBlock
                             .AddAndUseBlock($"{dictionary.Key} : function({paramsString})", terminationString: ",")
                             .AddStatement($"return `{transformedValue}`;");
                     }
                     else
                     {
-                        block
+                        interfaceBlock
+                            .AddStatement($"{dictionary.Key} : string;");
+
+                        varBlock
                             .AddStatement($"{dictionary.Key} : `{originalValue}`,");
                     }
                 }

--- a/src/WebApiToTypeScript/Resources/ResourceService.cs
+++ b/src/WebApiToTypeScript/Resources/ResourceService.cs
@@ -20,7 +20,7 @@ namespace WebApiToTypeScript.Resources
                 var resourceBlock = CreateResourceBlock();
 
                 var block = resourceBlock
-                    .AddAndUseBlock($"export class {resourceFilename}");
+                    .AddAndUseBlock($"export var {resourceFilename} = ");
 
                 var resourceReader = new ResXResourceReader(resourceConfig.SourcePath);
                 var dictionary = resourceReader.GetEnumerator();
@@ -64,14 +64,13 @@ namespace WebApiToTypeScript.Resources
                             .Replace("{", "${");
 
                         block
-                            .AddAndUseBlock($"static {dictionary.Key}({paramsString})")
+                            .AddAndUseBlock($"{dictionary.Key} : function({paramsString})", terminationString: ",")
                             .AddStatement($"return `{transformedValue}`;");
                     }
                     else
                     {
                         block
-                            .AddAndUseBlock($"static get {dictionary.Key}()")
-                            .AddStatement($"return `{originalValue}`;");
+                            .AddStatement($"{dictionary.Key} : `{originalValue}`,");
                     }
                 }
 

--- a/src/WebApiToTypeScript/ServiceAware.cs
+++ b/src/WebApiToTypeScript/ServiceAware.cs
@@ -6,7 +6,6 @@ namespace WebApiToTypeScript
 {
     public abstract class ServiceAware
     {
-        protected string IHaveQueryParams = WebApiToTypeScript.IHaveQueryParams;
         protected string IEndpoint = WebApiToTypeScript.IEndpoint;
 
         protected TypeService TypeService

--- a/src/WebApiToTypeScript/Types/TypeService.cs
+++ b/src/WebApiToTypeScript/Types/TypeService.cs
@@ -214,7 +214,7 @@ namespace WebApiToTypeScript.Types
             {
                 if (!Config.GenerateInterfaces)
                 {
-                    result.TypeName = $"{WebApiToTypeScript.IHaveQueryParams}";
+                    result.TypeName = $"any";
                     result.InterfaceName = "any";
                 }
                 else

--- a/src/WebApiToTypeScript/Types/TypeService.cs
+++ b/src/WebApiToTypeScript/Types/TypeService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Mono.Cecil;
 using WebApiToTypeScript.Config;
+using System.Diagnostics;
 
 namespace WebApiToTypeScript.Types
 {
@@ -286,7 +287,7 @@ namespace WebApiToTypeScript.Types
             return null;
         }
 
-        public string StripCollection(TypeReference type)
+        private string StripCollection(TypeReference type)
         {
             if (type.IsArray)
             {

--- a/src/WebApiToTypeScript/Views/ViewsService.cs
+++ b/src/WebApiToTypeScript/Views/ViewsService.cs
@@ -131,17 +131,23 @@ namespace WebApiToTypeScript.Views
 
         private void WriteViewEntry(TypeScriptBlock viewsBlock, ViewNode featureViewNode, bool isChild = false)
         {
-            var viewNamespace = Config.UseViewsGroupingNamespace && !isChild
-                ? ".Views"
+            var namespaceBlock = !isChild ? $"export namespace {featureViewNode.Name}" : $"{featureViewNode.Name} : ";
+            var featureBlock = viewsBlock
+                .AddAndUseBlock(namespaceBlock, terminationString: isChild ? "," : "");
+
+            var viewGroup = Config.UseViewsGroupingNamespace && !isChild
+                ? "Views"
                 : string.Empty;
 
-            var featureBlock = viewsBlock
-                .AddAndUseBlock($"export namespace {featureViewNode.Name}{viewNamespace}");
+            if (!string.IsNullOrEmpty(viewGroup))
+            {
+                featureBlock = featureBlock.AddAndUseBlock($"export var {viewGroup} = ");
+            }
 
             foreach (var viewEntry in featureViewNode.ViewEntries)
             {
                 featureBlock
-                    .AddStatement($"export const {viewEntry.Name} = '{viewEntry.Path}';");
+                    .AddStatement($"{viewEntry.Name} : '{viewEntry.Path}',");
             }
 
             foreach (var childView in featureViewNode.ChildViews)

--- a/src/WebApiToTypeScript/WebApi/WebApiAction.cs
+++ b/src/WebApiToTypeScript/WebApi/WebApiAction.cs
@@ -144,7 +144,7 @@ namespace WebApiToTypeScript.WebApi
             return constructorParametersList;
         }
 
-        public IOrderedEnumerable<ConstructorParameterMapping> GetConstructorParameterMappings()
+        public ConstructorParameterMapping[] GetConstructorParameterMappings()
         {
             var tempConstructorParameters = Method.Parameters
                 .Select(p => new
@@ -172,10 +172,11 @@ namespace WebApiToTypeScript.WebApi
                     IsOptional = routePart.IsOptional && TypeService.IsParameterOptional(routePart.Parameter),
                     TypeMapping = routePart.GetTypeMapping(),
                     Name = routePart.Parameter.Name,
-                    StringWithOptionals = routePart.GetParameterString(),
-                    String = routePart.GetParameterString(withOptionals: false)
+                    StringWithOptionals = routePart.GetParameterString(interfaceName: true),
+                    String = routePart.GetParameterString(withOptionals: false, interfaceName: true)
                 })
-                .OrderBy(p => p.IsOptional);
+                .OrderBy(p => p.IsOptional)
+                .ToArray();
 
             return constructorParameterMappings;
         }

--- a/src/WebApiToTypeScript/WebApi/WebApiRoutePart.cs
+++ b/src/WebApiToTypeScript/WebApi/WebApiRoutePart.cs
@@ -78,5 +78,10 @@ namespace WebApiToTypeScript.WebApi
             return (typeMatches && !matchExists)
                 || (typeMatches && doesPatternMatch);
         }
+
+        public override string ToString()
+        {
+            return this.ParameterName;
+        }
     }
 }

--- a/src/WebApiToTypeScript/WebApiToTypeScript.cs
+++ b/src/WebApiToTypeScript/WebApiToTypeScript.cs
@@ -20,8 +20,7 @@ namespace WebApiToTypeScript
     public class WebApiToTypeScript : AppDomainIsolatedTask
     {
         private Stopwatch stopwatch;
-
-        public const string IHaveQueryParams = nameof(IHaveQueryParams);
+                
         public const string IEndpoint = nameof(IEndpoint);
 
         public static Config.Config Config { get; private set; }


### PR DESCRIPTION
Improve performance and size when compiling for ES5. Will cause things to break if using classes of endpoints and/or classes of data types. Had to convert everything to interfaces. #27 